### PR TITLE
Add LM-X binary env var

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,7 @@ Unreleased
 - fix command to reload systemd settings when installing
 - add config options to set the path to rlmutil and lmutil
 - add config options to set the path for ls-dyna
+- add config options to set the path for lm-x
 
 0.0.1 - 2021-11-10
 ------------------

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ license-manager-agent:
   lmutil-path: "/usr/local/bin/lmutil"
   rlmutil-path: "/usr/local/bin/rlmutil"
   lsdyna-path: "/usr/local/bin/lstc_qrun"
+  lmxendutil-path: "/usr/local/bin/lmxendutil"
   auth0-domain: "<domain-collected-from-auth0>"
   auth0-audience: "<audience-for-auth0-api>"
   auth0-client-id: "<client-id-for-auth0-app>"

--- a/config.yaml
+++ b/config.yaml
@@ -49,6 +49,11 @@ options:
     default:
     description: |
       Path to the LS-Dyna binary. Leave blank if not needed.
+  lmxendutil-path:
+    type: string
+    default:
+    description: |
+      Path to the LM-X binary. Leave blank if not needed.
   auth0-domain:
     type: string
     default:

--- a/src/license_manager_agent_ops.py
+++ b/src/license_manager_agent_ops.py
@@ -148,6 +148,7 @@ class LicenseManagerAgentOps:
         lmutil_path = charm_config.get("lmutil-path")
         rlmutil_path = charm_config.get("rlmutil-path")
         lsdyna_path = charm_config.get("lsdyna-path")
+        lmxendutil_path = charm_config.get("lmxendutil-path")
         auth0_domain = charm_config.get("auth0-domain")
         auth0_audience = charm_config.get("auth0-audience")
         auth0_client_id = charm_config.get("auth0-client-id")
@@ -163,6 +164,7 @@ class LicenseManagerAgentOps:
             "lmutil_path": lmutil_path,
             "rlmutil_path": rlmutil_path,
             "lsdyna_path": lsdyna_path,
+            "lmxendutil_path": lmxendutil_path,
             "auth0_domain": auth0_domain,
             "auth0_audience": auth0_audience,
             "auth0_client_id": auth0_client_id,

--- a/src/templates/license-manager.defaults.template
+++ b/src/templates/license-manager.defaults.template
@@ -11,6 +11,9 @@ LM2_AGENT_RLMUTIL_PATH={{ rlmutil_path }}
 {% if lsdyna_path %}
 LM2_AGENT_LSDYNA_PATH={{ lsdyna_path }}
 {% endif %}
+{% if lmxendutil_path %}
+LM2_AGENT_LMXENDUTIL_PATH={{ lmxendutil_path }}
+{% endif %}
 LM2_AGENT_AUTH0_DOMAIN={{ auth0_domain }}
 LM2_AGENT_AUTH0_AUDIENCE={{ auth0_audience }}
 LM2_AGENT_AUTH0_CLIENT_ID={{ auth0_client_id }}


### PR DESCRIPTION
What
Add LM-X binary path env var.

Why
We'll need it when we start supporting LM-X license server.

Depends on: https://github.com/omnivector-solutions/license-manager/pull/122