### PR TITLE
Remove use-deprecated flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ license-manager-agent:
   auth0-audience: "<audience-for-auth0-api>"
   auth0-client-id: "<client-id-for-auth0-app>"
   auth0-client-secret: "<client-secret-for-auth0-app>"
+  sentry-dsn: ""
 ```
 
 ### Deploy the charm

--- a/src/license_manager_agent_ops.py
+++ b/src/license_manager_agent_ops.py
@@ -73,7 +73,6 @@ class LicenseManagerAgentOps:
         upgrade_pip_cmd = [
             self._PIP_CMD,
             "install",
-            "--use-deprecated=html5lib",
             "--upgrade",
             "pip",
         ]
@@ -132,7 +131,6 @@ class LicenseManagerAgentOps:
         pip_install_cmd = [
             self._PIP_CMD,
             "install",
-            "--use-deprecated=html5lib",
             "--upgrade",
             "-f",
             self._derived_pypi_url(),

--- a/src/license_manager_agent_ops.py
+++ b/src/license_manager_agent_ops.py
@@ -81,7 +81,6 @@ class LicenseManagerAgentOps:
         pip_install_cmd = [
             self._PIP_CMD,
             "install",
-            "--use-deprecated=html5lib",
             "-f",
             self._derived_pypi_url(),
             self._PACKAGE_NAME,


### PR DESCRIPTION
**What**
Remove the use-deprecated flag from the pip install commands.

**Why**
It was preventing the charm to install.