### PR TITLE
Add config to control if reconcile is triggered by prolog/epilog

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,7 @@ Unreleased
 - add config options to set the path to rlmutil and lmutil
 - add config options to set the path for ls-dyna
 - add config options to set the path for lm-x
+- add config options to set if reconciliation should run during Prolog/Epilog execution
 
 0.0.1 - 2021-11-10
 ------------------

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,7 +11,7 @@ Unreleased
 - add config options to set the path to rlmutil and lmutil
 - add config options to set the path for ls-dyna
 - add config options to set the path for lm-x
-- add config options to set if reconciliation should run during Prolog/Epilog execution
+- add config option to define if reconciliation should run during Prolog/Epilog execution
 
 0.0.1 - 2021-11-10
 ------------------

--- a/README.md
+++ b/README.md
@@ -76,8 +76,14 @@ $ git push --tags
 
 ### Change configuration
 
-To modify the charm configuration after it was deployed:
+To modify the charm configuration after it was deployed, use the `juju config` command. For example:
 ```bash
 juju config license-manager-agent license-manager-backend-base-url=somenewvalue
 ```
-Running the above command will tell the charm to reconfigure and restart license-manager-agent.
+
+If you wish to prevent Prolog/Epilog scripts from triggering a forced reconciliation, run:
+```bash
+juju config license manager-agent use-reconcile-in-prolog-epilog=false
+```
+
+Running the `juju config` command will tell the charm to reconfigure and restart license-manager-agent.

--- a/config.yaml
+++ b/config.yaml
@@ -56,7 +56,7 @@ options:
       Path to the LM-X binary. Leave blank if not needed.
   use_reconcile_in_prolog_epilog:
     type: boolean
-    default: true
+    default: True
     description: |
       Flags if reconciliation should be triggered when running Prolog/Epilog scripts. Defaults to true.
   auth0-domain:

--- a/config.yaml
+++ b/config.yaml
@@ -54,6 +54,11 @@ options:
     default:
     description: |
       Path to the LM-X binary. Leave blank if not needed.
+  use_reconcile_in_prolog_epilog:
+    type: boolean
+    default: true
+    description: |
+      Flags if reconciliation should be triggered when running Prolog/Epilog scripts. Defaults to true.
   auth0-domain:
     type: string
     default:

--- a/config.yaml
+++ b/config.yaml
@@ -54,7 +54,7 @@ options:
     default:
     description: |
       Path to the LM-X binary. Leave blank if not needed.
-  use_reconcile_in_prolog_epilog:
+  use-reconcile-in-prolog-epilog:
     type: boolean
     default: True
     description: |

--- a/src/license_manager_agent_ops.py
+++ b/src/license_manager_agent_ops.py
@@ -161,6 +161,7 @@ class LicenseManagerAgentOps:
         auth0_audience = charm_config.get("auth0-audience")
         auth0_client_id = charm_config.get("auth0-client-id")
         auth0_client_secret = charm_config.get("auth0-client-secret")
+        use_reconcile_in_prolog_epilog = charm_config.get("use-reconcile-in-prolog-epilog")
 
         log_base_dir = str(self._LOG_DIR)
 
@@ -177,6 +178,7 @@ class LicenseManagerAgentOps:
             "auth0_audience": auth0_audience,
             "auth0_client_id": auth0_client_id,
             "auth0_client_secret": auth0_client_secret,
+            "use_reconcile_in_prolog_epilog": use_reconcile_in_prolog_epilog,
         }
 
         template_dir = Path("./src/templates/")

--- a/src/templates/license-manager.defaults.template
+++ b/src/templates/license-manager.defaults.template
@@ -14,6 +14,7 @@ LM2_AGENT_LSDYNA_PATH={{ lsdyna_path }}
 {% if lmxendutil_path %}
 LM2_AGENT_LMXENDUTIL_PATH={{ lmxendutil_path }}
 {% endif %}
+LM2_AGENT_USE_RECONCILE_IN_PROLOG_EPILOG={{ use_reconcile_in_prolog_epilog }}
 LM2_AGENT_AUTH0_DOMAIN={{ auth0_domain }}
 LM2_AGENT_AUTH0_AUDIENCE={{ auth0_audience }}
 LM2_AGENT_AUTH0_CLIENT_ID={{ auth0_client_id }}


### PR DESCRIPTION
#### What
Add a config to set the agent env var that flags if reconciliation should be triggered by Prolog/Epilog execution.

#### Why
To be able to run Prolog/Epilog without triggering a forced reconciliation.

`Task`: https://app.clickup.com/t/18022949/LM-190

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
