### PR TITLE
Add default value to Sentry DSN config

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ license-manager-agent:
   auth0-audience: "<audience-for-auth0-api>"
   auth0-client-id: "<client-id-for-auth0-app>"
   auth0-client-secret: "<client-secret-for-auth0-app>"
-  sentry-dsn: ""
 ```
 
 ### Deploy the charm

--- a/config.yaml
+++ b/config.yaml
@@ -36,7 +36,7 @@ options:
       PYPI PASSWORD in plain text.
   sentry-dsn:
     type: string
-    default:
+    default: ""
     description: |
       Sentry DSN url.
   lmutil-path:

--- a/src/templates/license-manager.defaults.template
+++ b/src/templates/license-manager.defaults.template
@@ -1,7 +1,9 @@
 LM2_AGENT_BACKEND_BASE_URL={{ license_manager_backend_base_url }}
 LM2_AGENT_LOG_BASE_DIR={{ log_base_dir }}
 LM2_AGENT_LOG_LEVEL={{ log_level }}
+{% if sentry_dsn %}
 LM2_AGENT_SENTRY_DSN={{ sentry_dsn }}
+{% endif %}
 {% if lmutil_path %}
 LM2_AGENT_LMUTIL_PATH={{ lmutil_path }}
 {% endif %}

--- a/src/templates/license-manager.defaults.template
+++ b/src/templates/license-manager.defaults.template
@@ -1,9 +1,7 @@
 LM2_AGENT_BACKEND_BASE_URL={{ license_manager_backend_base_url }}
 LM2_AGENT_LOG_BASE_DIR={{ log_base_dir }}
 LM2_AGENT_LOG_LEVEL={{ log_level }}
-{% if sentry_dsn %}
 LM2_AGENT_SENTRY_DSN={{ sentry_dsn }}
-{% endif %}
 {% if lmutil_path %}
 LM2_AGENT_LMUTIL_PATH={{ lmutil_path }}
 {% endif %}


### PR DESCRIPTION
#### What
Add an empty string as the default value to Sentry DSN config.

#### Why
If the config was not configured, the env var `LM2_AGENT_SENTRY_DSN` was getting literally a `"None"` string as its value, which was crashing the agent code.

`Task`: https://app.clickup.com/t/18022949/ARMADA-462

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
