### PR TITLE
Add Fluentbit integration

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,6 +13,7 @@ Unreleased
 - add config options to set the path for lm-x
 - add config option to define if reconciliation should run during Prolog/Epilog execution
 - add config option `timeout-interval` to terminate the service in case it hangs
+- add support to Fluentbit log forwarding
 
 0.0.1 - 2021-11-10
 ------------------

--- a/lib/charms/fluentbit/v0/fluentbit.py
+++ b/lib/charms/fluentbit/v0/fluentbit.py
@@ -1,0 +1,203 @@
+r"""Fluentbit charm libraries.
+
+This library contains two main classes: `FluentbitProvider` and
+`FluentbitClient`. `FluentbitProvider` class is instantiated in the Fluentbit
+Server charm, and receives configuration data through a relation to other
+charms. `FluentbitClient` class should be instantiated in any charm that wants
+to ship logs via Fluentbit.
+
+## Forwarding logs using Fluentbit
+
+To forward logs from your charm to a centralized place using Fluentbit,
+instantiate the `FluentbitClient()` class and handle the `relation_created`
+event in your main charm code. In this event, your charm must pass all the
+configuration parameters necessary to configure Fluentbit: the inputs, the
+parsers, and the filters.
+
+For example:
+
+```python
+class MyCharm(CharmBase):
+    def __init__(self, *args):
+        super().__init__(*args)
+
+        self._fluentbit = FluentbitClient(self, "fluentbit")
+
+        self.framework.observe(self.on.fluentbit.relation_created,
+                               self._fluentbit_relation_created)
+
+    def _fluentbit_relation_created(self, event):
+        cfg = [{"input": [("name",     "tail"),
+                          ("path",     "/var/log/foo/bar.log"),
+                          ("path_key", "filename"),
+                          ("tag",      "foo"),
+                          ("parser",   "bar")]},
+               {"parser": [("name",        "bar"),
+                           ("format",      "regex"),
+                           ("regex",       "^\[(?<time>[^\]]*)\] (?<log>.*)$"),
+                           ("time_key",    "time"),
+                           ("time_format", "%Y-%m-%dT%H,%M,%S.%L")]}]
+        self._fluentbit.configure(cfg)
+```
+
+The configuration object must be a list of dictionaries. Each dictionary must
+contain one key. The key must be the section of Fluentbit's processing
+pipeline. Valid ones are:
+- `input`
+- `filter`
+- `parser`
+- `multiline_parser`
+- `output`
+
+The value of each key must be a list of all configuration entries. Each entry
+is a tuple (or list) of values to be rendered in the configuration files.
+
+Your charm's `metadata.yaml` should have the Fluentbit relation entry in the
+`requires` section:
+
+```
+requires:
+      fluentbit:
+          interface: fluentbit
+```
+
+
+## FluentbitProvider class
+
+This class receives the configuration data and forwards to the Fluentbit Charm,
+to rewrite the configuration files and restart the service. This class should
+only be instantiated by Fluentbit Charm.
+
+## Caveats
+
+The charm does not validate the configuration files before restarting the
+service. It is the charm author's responsibility to ensure the configuration is
+correct.
+"""
+
+import logging
+import json
+from typing import List
+
+from ops.framework import EventBase, EventSource, Object, ObjectEvents, StoredState
+from ops.model import Relation
+
+# The unique Charmhub library identifier, never change it
+LIBID = "e7b5ae1460034b9fb67cd4ec6aa3e87f"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 2
+
+logger = logging.getLogger(__name__)
+
+
+class FluentbitConfigurationAvailable(EventBase):
+    """Emitted when configuration is available."""
+
+
+class FluentbitEvents(ObjectEvents):
+    """Fluentbit emitted events."""
+
+    configuration_available = EventSource(FluentbitConfigurationAvailable)
+
+
+class FluentbitProvider(Object):
+    """Implement the provider side of the relation."""
+
+    _state = StoredState()
+    on = FluentbitEvents()
+
+    def __init__(self, charm, relation_name: str):
+        """Initialize the service provider.
+
+        Arguments:
+            charm: a `CharmBase` instance that manages this instance of the
+                   Fluentbit service.
+            relation_name: string name of the relation that provides the
+                           Fluentbit logging service.
+        """
+        super().__init__(charm, relation_name)
+
+        self.charm = charm
+        self._relation_name = relation_name
+
+        self._state.set_default(cfg=str())
+
+        events = self.charm.on[relation_name]
+        self.framework.observe(events.relation_changed, self._on_relation_changed)
+        # TODO relation_broken should reconfigure with empty/default values,
+        #      with care to not remove other entries from other relations
+
+    def _on_relation_changed(self, event):
+        """Get configuration from the client and trigger a reconfiguration."""
+        cfg = event.relation.data[event.unit].get("configuration")
+        logger.debug(f"## relation-changed: received: {cfg}")
+        # TODO this only works for 1 relation, should extend for any number of
+        #      relations, so it can support multiple outputs easily?
+        if cfg:
+            self._state.cfg = cfg
+            self.on.configuration_available.emit()
+
+    @property
+    def configuration(self) -> List[dict]:
+        """Get the stored configuration.
+
+        Returns:
+            list of dictionaries with the configuration parameters.
+        """
+        cfg = json.loads(self._state.cfg or '[]')
+        logger.debug(f"## Fluentbit stored configuration: {cfg}")
+        return cfg
+
+
+class FluentbitClient(Object):
+    """A client to relate to a Fluentbit Charm.
+
+    This class implements the `requires` end of the relation, to configure
+    Fluentbit.
+
+    The instantiating class must handle the `relation_created` event to
+    configure Fluentbit:
+    """
+    def __init__(self, charm, relation_name: str):
+        """Initialize Fluentbit client.
+
+        Arguments:
+            charm: a `CharmBase` object that manages this `FluentbitClient`
+                   object. Typically this is `self` in the instantiating class.
+            relation_name: string name of the relation between `charm` and the
+                           Fluentbit charmed service.
+        """
+        super().__init__(charm, relation_name)
+
+        self._charm = charm
+        self._relation_name = relation_name
+
+    def configure(self, cfg: List[dict]):
+        r"""Configure Fluentbit.
+
+        Arguments:
+            cfg: a list of stuff to setup. Example:
+                [{"input": [("name",     "tail"),
+                            ("path",     "/var/log/slurm/slurmd.log"),
+                            ("path_key", "filename"),
+                            ("tag",      "slurmd"),
+                            ("parser",   "slurm")]},
+                 {"parser": [("name",        "slurm"),
+                             ("format",      "regex"),
+                             ("regex",       "^\[(?<time>[^\]]*)\] (?<message>.*)$"),
+                             ("time_key",    "time"),
+                             ("time_format", "%Y-%m-%dT%H,%M,%S.%L")]},
+        """
+        # should we validate the input? how?
+        logging.debug(f"## Seding configuration data to Fluentbit: {cfg}")
+        self._relation.data[self.model.unit]["configuration"] = json.dumps(cfg)
+
+    @property
+    def _relation(self) -> Relation:
+        """Return the relation."""
+        return self.framework.model.get_relation(self._relation_name)

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -21,3 +21,5 @@ requires:
         scope: container
     prolog-epilog:
         interface: prolog-epilog
+    fluentbit:
+        interface: fluentbit

--- a/src/charm.py
+++ b/src/charm.py
@@ -94,8 +94,6 @@ class LicenseManagerAgentCharm(CharmBase):
     def _on_fluentbit_relation_created(self, event):
         """Set up Fluentbit log forwarding."""
         cfg = list()
-        cfg.extend(self._license_manager_agent_ops.fluentbit_config_epilog_log)
-        cfg.extend(self._license_manager_agent_ops.fluentbit_config_prolog_log)
         cfg.extend(self._license_manager_agent_ops.fluentbit_config_lm_log)
         self._fluentbit.configure(cfg)
 

--- a/src/license_manager_agent_ops.py
+++ b/src/license_manager_agent_ops.py
@@ -233,46 +233,14 @@ class LicenseManagerAgentOps:
         rmtree(self._VENV_DIR.as_posix(), ignore_errors=True)
 
     @property
-    def fluentbit_config_epilog_log(self) -> list:
-        """Return Fluentbit configuration parameters to forward Epilog logs."""
-        cfg = [{"input": [("name",             "tail"),
-                          ("path",             "/var/log/license-manager-agent/slurmctld-epilog.log"),
-                          ("path_key",         "filename"),
-                          ("tag",              "epilog"),
-                          ("multiline.parser", "epilog")]},
-               {"multiline_parser": [("name",          "epilog"),
-                                     ("type",          "regex"),
-                                     ("flush_timeout", "1000"),
-                                     ("rule",          '"start_state"', '"^\[\d+-\d+-\d+ \d+:\d+:\d+,\d+\;\w+\] \w+.\w+:\d+ - \s+ .+"', '"cont"'), # noqa
-                                     ("rule",          '"cont"',        '"(.*)"',             '"cont"')]}] # noqa
-        return cfg
-
-    @property
-    def fluentbit_config_prolog_log(self) -> list:
-        """Return Fluentbit configuration parameters to forward Prolog logs."""
-        cfg = [{"input": [("name",             "tail"),
-                          ("path",             "/var/log/license-manager-agent/slurmctld-prolog.log"),
-                          ("path_key",         "filename"),
-                          ("tag",              "prolog"),
-                          ("multiline.parser", "prolog")]},
-               {"multiline_parser": [("name",          "prolog"),
-                                     ("type",          "regex"),
-                                     ("flush_timeout", "1000"),
-                                     ("rule",          '"start_state"', '"^\[\d+-\d+-\d+ \d+:\d+:\d+,\d+\;\w+\] \w+.\w+:\d+ - \s+ .+"', '"cont"'), # noqa
-                                     ("rule",          '"cont"',        '"(.*)"',             '"cont"')]}] # noqa
-        return cfg
-    
-    @property
     def fluentbit_config_lm_log(self) -> list:
         """Return Fluentbit configuration parameters to forward LM agent logs."""
         cfg = [{"input": [("name",             "tail"),
-                          ("path",             "/var/log/license-manager-agent/license-manager-agent.log"),
-                          ("path_key",         "filename"),
-                          ("tag",              "lm"),
-                          ("multiline.parser", "lm")]},
-               {"multiline_parser": [("name",          "lm"),
+                          ("path",             "/var/log/license-manager-agent/*.log"),
+                          ("multiline.parser", "multiline-lm")]},
+               {"multiline_parser": [("name",          "multiline-lm"),
                                      ("type",          "regex"),
                                      ("flush_timeout", "1000"),
-                                     ("rule",          '"start_state"', '"^\[\d+-\d+-\d+ \d+:\d+:\d+,\d+\;\w+\] \w+.\w+:\d+ - \s+ .+"', '"cont"'), # noqa
-                                     ("rule",          '"cont"',        '"(.*)"',             '"cont"')]}] # noqa
+                                     ("rule",          '"start_state"', '"/^\[(\d+(\-)?){3} (\d+(\:)?){3},\d+\;\w+\] .+/"', '"cont"'), # noqa
+                                     ("rule",          '"cont"',        '"/^([^\[].*)/"',             '"cont"')]}] # noqa
         return cfg

--- a/src/license_manager_agent_ops.py
+++ b/src/license_manager_agent_ops.py
@@ -231,3 +231,48 @@ class LicenseManagerAgentOps:
             self._ETC_DEFAULT.unlink()
         rmtree(self._LOG_DIR.as_posix(), ignore_errors=True)
         rmtree(self._VENV_DIR.as_posix(), ignore_errors=True)
+
+    @property
+    def fluentbit_config_epilog_log(self) -> list:
+        """Return Fluentbit configuration parameters to forward Epilog logs."""
+        cfg = [{"input": [("name",             "tail"),
+                          ("path",             "/var/log/license-manager-agent/slurmctld-epilog.log"),
+                          ("path_key",         "filename"),
+                          ("tag",              "epilog"),
+                          ("multiline.parser", "epilog")]},
+               {"multiline_parser": [("name",          "epilog"),
+                                     ("type",          "regex"),
+                                     ("flush_timeout", "1000"),
+                                     ("rule",          '"start_state"', '"^\[\d+-\d+-\d+ \d+:\d+:\d+,\d+\;\w+\] \w+.\w+:\d+ - \s+ .+"', '"cont"'), # noqa
+                                     ("rule",          '"cont"',        '"(.*)"',             '"cont"')]}] # noqa
+        return cfg
+
+    @property
+    def fluentbit_config_prolog_log(self) -> list:
+        """Return Fluentbit configuration parameters to forward Prolog logs."""
+        cfg = [{"input": [("name",             "tail"),
+                          ("path",             "/var/log/license-manager-agent/slurmctld-prolog.log"),
+                          ("path_key",         "filename"),
+                          ("tag",              "prolog"),
+                          ("multiline.parser", "prolog")]},
+               {"multiline_parser": [("name",          "prolog"),
+                                     ("type",          "regex"),
+                                     ("flush_timeout", "1000"),
+                                     ("rule",          '"start_state"', '"^\[\d+-\d+-\d+ \d+:\d+:\d+,\d+\;\w+\] \w+.\w+:\d+ - \s+ .+"', '"cont"'), # noqa
+                                     ("rule",          '"cont"',        '"(.*)"',             '"cont"')]}] # noqa
+        return cfg
+    
+    @property
+    def fluentbit_config_lm_log(self) -> list:
+        """Return Fluentbit configuration parameters to forward LM agent logs."""
+        cfg = [{"input": [("name",             "tail"),
+                          ("path",             "/var/log/license-manager-agent/license-manager-agent.log"),
+                          ("path_key",         "filename"),
+                          ("tag",              "lm"),
+                          ("multiline.parser", "lm")]},
+               {"multiline_parser": [("name",          "lm"),
+                                     ("type",          "regex"),
+                                     ("flush_timeout", "1000"),
+                                     ("rule",          '"start_state"', '"^\[\d+-\d+-\d+ \d+:\d+:\d+,\d+\;\w+\] \w+.\w+:\d+ - \s+ .+"', '"cont"'), # noqa
+                                     ("rule",          '"cont"',        '"(.*)"',             '"cont"')]}] # noqa
+        return cfg

--- a/src/license_manager_agent_ops.py
+++ b/src/license_manager_agent_ops.py
@@ -237,6 +237,7 @@ class LicenseManagerAgentOps:
         """Return Fluentbit configuration parameters to forward LM agent logs."""
         cfg = [{"input": [("name",             "tail"),
                           ("path",             "/var/log/license-manager-agent/*.log"),
+                          ("tag",              "lm.*"),
                           ("multiline.parser", "multiline-lm")]},
                {"multiline_parser": [("name",          "multiline-lm"),
                                      ("type",          "regex"),


### PR DESCRIPTION
#### What
Add Fluentbit integratino to forward logs.

#### Why
To be able to export the logs to a logging platform, such as Graylog.

`Task`: https://app.clickup.com/t/18022949/ARMADA-463

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
