### PR TITLE
Clear cache in charms after install or upgrade

### DIFF
--- a/src/license_manager_agent_ops.py
+++ b/src/license_manager_agent_ops.py
@@ -220,6 +220,9 @@ class LicenseManagerAgentOps:
 
         self._ETC_DEFAULT.write_text(rendered_template)
 
+        # Clear cache dir after upgrade to avoid stale data
+        self.setup_cache_dir()
+
     def license_manager_agent_systemctl(self, operation: str):
         """Run license-manager-agent systemctl command."""
 

--- a/src/license_manager_agent_ops.py
+++ b/src/license_manager_agent_ops.py
@@ -1,12 +1,10 @@
 """LicenseManagerAgentOps."""
 import logging
-import shutil
 import subprocess
 from pathlib import Path
-from shutil import copy2, rmtree, chown
+from shutil import chown, copy2, rmtree
 
 from jinja2 import Environment, FileSystemLoader
-
 
 logger = logging.getLogger()
 
@@ -259,13 +257,28 @@ class LicenseManagerAgentOps:
     @property
     def fluentbit_config_lm_log(self) -> list:
         """Return Fluentbit configuration parameters to forward LM agent logs."""
-        cfg = [{"input": [("name",             "tail"),
-                          ("path",             "/var/log/license-manager-agent/*.log"),
-                          ("tag",              "lm.*"),
-                          ("multiline.parser", "multiline-lm")]},
-               {"multiline_parser": [("name",          "multiline-lm"),
-                                     ("type",          "regex"),
-                                     ("flush_timeout", "1000"),
-                                     ("rule",          '"start_state"', '"/^\[(\d+(\-)?){3} (\d+(\:)?){3},\d+\;\w+\] .+/"', '"cont"'), # noqa
-                                     ("rule",          '"cont"',        '"/^([^\[].*)/"',             '"cont"')]}] # noqa
+        cfg = [
+            {
+                "input": [
+                    ("name", "tail"),
+                    ("path", "/var/log/license-manager-agent/*.log"),
+                    ("tag", "lm.*"),
+                    ("multiline.parser", "multiline-lm"),
+                ]
+            },
+            {
+                "multiline_parser": [
+                    ("name", "multiline-lm"),
+                    ("type", "regex"),
+                    ("flush_timeout", "1000"),
+                    (
+                        "rule",
+                        '"start_state"',
+                        '"/^\[(\d+(\-)?){3} (\d+(\:)?){3},\d+\;\w+\] .+/"',
+                        '"cont"',
+                    ),  # noqa
+                    ("rule", '"cont"', '"/^([^\[].*)/"', '"cont"'),
+                ]
+            },
+        ]  # noqa
         return cfg

--- a/src/license_manager_agent_ops.py
+++ b/src/license_manager_agent_ops.py
@@ -40,9 +40,15 @@ class LicenseManagerAgentOps:
 
         # Delete cache dir if it already exists
         if CACHE_DIR.exists():
+            logger.debug(f"Clearing cache dir {CACHE_DIR.as_posix()}")
             rmtree(CACHE_DIR, ignore_errors=True)
+        else:
+            logger.debug(
+                f"Tried to clean cache dir {CACHE_DIR.as_posix()}, but it does not exist"
+            )
 
         # Create a clean cache dir
+        logger.debug(f"Creating a clean cache dir {CACHE_DIR.as_posix()}")
         CACHE_DIR.mkdir(parents=True)
         chown(CACHE_DIR.as_posix(), self._SLURM_USER, self._SLURM_GROUP)
         CACHE_DIR.chmod(0o700)


### PR DESCRIPTION
The token caches for the Vantage services (agents and CLIs) need to be cleared out after the charm has been installed or upgraded. Add logic to clear the cache to the charm code.

https://app.clickup.com/t/18022949/ARMADA-854