### PR TITLE
Add status update to end of upgrade action

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -89,7 +89,14 @@ class LicenseManagerAgentCharm(CharmBase):
 
     def _upgrade_to_latest(self, event):
         version = event.params["version"]
-        self._license_manager_agent_ops.upgrade(version)
+        try:
+            self._license_manager_agent_ops.upgrade(version)
+            event.set_results({"upgrade": "success"})
+            self._license_manager_agent_ops.restart_license_manager_agent()
+        except Exception:
+            self.unit.status = BlockedStatus("Error upgrading license-manager-agent")
+            event.fail(message="Error upgrading license-manager-agent")
+            event.defer()
 
     def _on_fluentbit_relation_created(self, event):
         """Set up Fluentbit log forwarding."""


### PR DESCRIPTION
Each of the juju charms should update their statuses at the end of the upgrade action. Otherwise, we have to wait for 5 minutes for juju to run another check.

https://app.clickup.com/t/18022949/ARMADA-852