### PR TITLE
Update Makefile to copy and rename the charm after packing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,3 +19,4 @@ clean: ## Remove build dirs, temp files, and charms
 .PHONY: charm
 charm: version ## Pack the charm
 	@charmcraft pack
+	@cp license-manager-agent_ubuntu-20.04-amd64_centos-7-amd64.charm license-manager-agent.charm


### PR DESCRIPTION
**What**

Update de Makefile, adding a copy command after the `charmcraft pack `is completed. It will make a copy of the `.charm` with a better name.

**Why**

To standardize the charms files name, applying a short one.