### PR TITLE
ASP-2377: Add an action to show the version of license-manager-agent

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ This file keeps track of all notable changes to the License Manager Agent Charm.
 
 Unreleased
 ----------
+* Add an action to show the version of license-manager-agent. 
 * Fix command to reload systemd settings when installing
 * Add config options to set the path to rlmutil (RLM binary) and lmutil (FlexLM binary)
 * Add config options to set the path for lsdyna (LS-Dyna binary)

--- a/actions.yaml
+++ b/actions.yaml
@@ -7,3 +7,7 @@ upgrade:
       description: Version of license-manager to upgrade to.
   required:
     - version
+
+show-version:
+  description: >
+    Display the version and information about license-manager-agent.

--- a/src/charm.py
+++ b/src/charm.py
@@ -43,6 +43,7 @@ class LicenseManagerAgentCharm(CharmBase):
             self.on.config_changed: self._on_config_changed,
             self.on.remove: self._on_remove,
             self.on.upgrade_action: self._on_upgrade_action,
+            self.on.show_version_action: self._on_show_version_action,
             self.on["fluentbit"].relation_created: self._on_fluentbit_relation_created,
         }
         for event, handler in event_handler_bindings.items():
@@ -70,6 +71,11 @@ class LicenseManagerAgentCharm(CharmBase):
     def _on_upgrade(self, event):
         """Perform upgrade operations."""
         self.unit.set_workload_version(Path("version").read_text().strip())
+
+    def _on_show_version_action(self, event):
+        """Show the info and version of license-manager-agent."""
+        info = self._license_manager_agent_ops.get_version_info()
+        event.set_results({"license-manager-agent": info})
 
     def _on_start(self, event):
         """Start the license-manager-agent service."""

--- a/src/charm.py
+++ b/src/charm.py
@@ -39,6 +39,7 @@ class LicenseManagerAgentCharm(CharmBase):
 
         event_handler_bindings = {
             self.on.install: self._on_install,
+            self.on.upgrade_charm: self._on_upgrade,
             self.on.start: self._on_start,
             self.on.config_changed: self._on_config_changed,
             self.on.remove: self._on_remove,

--- a/src/license_manager_agent_ops.py
+++ b/src/license_manager_agent_ops.py
@@ -166,6 +166,20 @@ class LicenseManagerAgentOps:
         # Clear cache dir after upgrade to avoid stale data
         self.setup_cache_dir()
 
+    def get_version_info(self):
+        """Show version and info about license-manager-agent."""
+        cmd = [
+            self._VENV_PYTHON,
+            "-m",
+            "pip",
+            "show",
+            self._PACKAGE_NAME
+        ]
+
+        out = subprocess.check_output(cmd, env={}).decode().strip()
+
+        return out
+
     def configure_etc_default(self):
         """Get the needed config, render and write out the file."""
         charm_config = self._charm.model.config


### PR DESCRIPTION
**What**

Add an action named` show-version` to display all information returned by `pip show license-manger-agent`, which includes the version of the package.

Usage: `juju run-action license-manager-agent/leader show-version --wait`

**Why**

With that, we can easily check the version and relate information about the software without the need to log in to the node.