### PR TITLE
[ASP-2608] Fix user creation

### DIFF
--- a/src/license_manager_agent_ops.py
+++ b/src/license_manager_agent_ops.py
@@ -40,7 +40,7 @@ class LicenseManagerAgentOps:
         """Set up cache dir."""
         # Delete cache dir if it already exists
         if self._CACHE_DIR.exists():
-            logger.debug(f"Clearing cache dir {self._CACHE_DIR.as_posix()}")
+            logger.debug(f"The cache directory already exists. Clearing it: {self._CACHE_DIR.as_posix()}")
             rmtree(self._CACHE_DIR, ignore_errors=True)
         else:
             logger.debug(

--- a/src/license_manager_agent_ops.py
+++ b/src/license_manager_agent_ops.py
@@ -51,7 +51,7 @@ class LicenseManagerAgentOps:
         logger.debug(f"Creating a clean cache dir {self._CACHE_DIR.as_posix()}")
         self._CACHE_DIR.mkdir(parents=True)
         chown(self._CACHE_DIR.as_posix(), self._SLURM_USER, self._SLURM_GROUP)
-        self._CACHE_DIR.chmod(0o770)
+        self._CACHE_DIR.chmod(0o777)
 
     def setup_log_dir(self):
         """Set up log dir."""
@@ -68,7 +68,7 @@ class LicenseManagerAgentOps:
         logger.debug(f"Creating a clean log dir {self._LOG_DIR.as_posix()}")
         self._LOG_DIR.mkdir(parents=True)
         chown(self._LOG_DIR.as_posix(), self._SLURM_USER, self._SLURM_GROUP)
-        self._LOG_DIR.chmod(0o770)
+        self._LOG_DIR.chmod(0o777)
 
     def setup_license_manager_user(self):
         """Set up license-manager user, account and group."""

--- a/src/license_manager_agent_ops.py
+++ b/src/license_manager_agent_ops.py
@@ -342,29 +342,27 @@ class LicenseManagerAgentOps:
         rmtree(self._VENV_DIR.as_posix(), ignore_errors=True)
 
         # Remove the agent user from the License Manager Slurm account
-        remove_account_cmd = [
+        remove_user_cmd = [
             "sacctmgr",
             "remove",
             "user"
-            "where",
-            "user=license-manager",
-            "account=license-manager",
+            _LICENSE_MANAGER_USER,
             "-i",
         ]
-        subprocess.call(remove_account_cmd)
+        subprocess.call(remove_user_cmd)
 
         # Remove the License Manager Slurm account
         remove_account_cmd = [
             "sacctmgr",
             "remove",
             "account",
-            "license-manager",
+            _LICENSE_MANAGER_ACCOUNT,
             "-i"
         ]
         subprocess.call(remove_account_cmd)
 
         # Remove the agent user
-        subprocess.call(["userdel", "license-manager"])
+        subprocess.call(["userdel", _LICENSE_MANAGER_USER])
 
     @property
     def fluentbit_config_lm_log(self) -> list:

--- a/src/license_manager_agent_ops.py
+++ b/src/license_manager_agent_ops.py
@@ -44,7 +44,7 @@ class LicenseManagerAgentOps:
             rmtree(self._CACHE_DIR, ignore_errors=True)
         else:
             logger.debug(
-                f"Tried to clean cache dir {self._CACHE_DIR.as_posix()}, but it does not exist"
+                f"Searched for the cache directory {self._CACHE_DIR.as_posix()}, but it does not exist; skipping for its creation"
             )
 
         # Create a clean cache dir

--- a/src/license_manager_agent_ops.py
+++ b/src/license_manager_agent_ops.py
@@ -120,7 +120,7 @@ class LicenseManagerAgentOps:
         logger.debug(f"license-manager-agent user added to account with operator admin level")
 
     def install(self):
-        """Install license-manager-agent and setup ops."""
+        """Install license-manager-agent and set up ops."""
         # Create the virtualenv
         create_venv_cmd = [
             self._PYTHON_BIN.as_posix(),

--- a/src/license_manager_agent_ops.py
+++ b/src/license_manager_agent_ops.py
@@ -77,7 +77,7 @@ class LicenseManagerAgentOps:
             "adduser",
             "--system",
             "--no-create-home",
-            _LICENSE_MANAGER_USER,
+            self._LICENSE_MANAGER_USER,
         ]
         subprocess.call(useradd_cmd)
         logger.debug(f"license-manager-agent user created")
@@ -87,8 +87,8 @@ class LicenseManagerAgentOps:
             "usermod",
             "-a",
             "-G",
-            _SLURM_GROUP,
-            _LICENSE_MANAGER_USER,
+            self._SLURM_GROUP,
+            self._LICENSE_MANAGER_USER,
         ]
         subprocess.call(usermod_cmd)
         logger.debug(f"license-manager-agent user added to slurm group")
@@ -98,7 +98,7 @@ class LicenseManagerAgentOps:
             "sacctmgr",
             "add",
             "account",
-            _LICENSE_MANAGER_ACCOUNT,
+            self._LICENSE_MANAGER_ACCOUNT,
             "Description=License Manager reservations account",
             "-i",
         ]
@@ -111,8 +111,8 @@ class LicenseManagerAgentOps:
             "sacctmgr",
             "add",
             "user",
-            _LICENSE_MANAGER_USER,
-            f"Account={_LICENSE_MANAGER_ACCOUNT}",
+            self._LICENSE_MANAGER_USER,
+            f"Account={self._LICENSE_MANAGER_ACCOUNT}",
             "AdminLevel=Operator",
             "-i",
         ]
@@ -346,7 +346,7 @@ class LicenseManagerAgentOps:
             "sacctmgr",
             "remove",
             "user",
-            _LICENSE_MANAGER_USER,
+            self._LICENSE_MANAGER_USER,
             "-i",
         ]
         subprocess.call(remove_user_cmd)
@@ -356,13 +356,13 @@ class LicenseManagerAgentOps:
             "sacctmgr",
             "remove",
             "account",
-            _LICENSE_MANAGER_ACCOUNT,
+            self._LICENSE_MANAGER_ACCOUNT,
             "-i"
         ]
         subprocess.call(remove_account_cmd)
 
         # Remove the agent user
-        subprocess.call(["userdel", _LICENSE_MANAGER_USER])
+        subprocess.call(["userdel", self._LICENSE_MANAGER_USER])
 
     @property
     def fluentbit_config_lm_log(self) -> list:

--- a/src/license_manager_agent_ops.py
+++ b/src/license_manager_agent_ops.py
@@ -15,6 +15,7 @@ class LicenseManagerAgentOps:
     _PYTHON_BIN = Path("/usr/bin/python3.8")
     _PACKAGE_NAME = "license-manager-agent"
     _LOG_DIR = Path("/var/log/license-manager-agent")
+    _CACHE_DIR = Path("/var/cache/license-manager")
     _ETC_DEFAULT = Path("/etc/default/license-manager-agent")
     _SYSTEMD_BASE_PATH = Path("/usr/lib/systemd/system")
     _SYSTEMD_SERVICE_NAME = "license-manager-agent.service"
@@ -34,22 +35,20 @@ class LicenseManagerAgentOps:
 
     def setup_cache_dir(self):
         """Set up cache dir."""
-        CACHE_DIR = Path("/var/cache/license-manager")
-
         # Delete cache dir if it already exists
-        if CACHE_DIR.exists():
-            logger.debug(f"Clearing cache dir {CACHE_DIR.as_posix()}")
-            rmtree(CACHE_DIR, ignore_errors=True)
+        if self._CACHE_DIR.exists():
+            logger.debug(f"Clearing cache dir {self._CACHE_DIR.as_posix()}")
+            rmtree(self._CACHE_DIR, ignore_errors=True)
         else:
             logger.debug(
-                f"Tried to clean cache dir {CACHE_DIR.as_posix()}, but it does not exist"
+                f"Tried to clean cache dir {self._CACHE_DIR.as_posix()}, but it does not exist"
             )
 
         # Create a clean cache dir
-        logger.debug(f"Creating a clean cache dir {CACHE_DIR.as_posix()}")
-        CACHE_DIR.mkdir(parents=True)
-        chown(CACHE_DIR.as_posix(), self._SLURM_USER, self._SLURM_GROUP)
-        CACHE_DIR.chmod(0o700)
+        logger.debug(f"Creating a clean cache dir {self._CACHE_DIR.as_posix()}")
+        self._CACHE_DIR.mkdir(parents=True)
+        chown(self._CACHE_DIR.as_posix(), self._SLURM_USER, self._SLURM_GROUP)
+        self._CACHE_DIR.chmod(0o770)
 
     def install(self):
         """Install license-manager-agent and setup ops."""

--- a/src/license_manager_agent_ops.py
+++ b/src/license_manager_agent_ops.py
@@ -98,7 +98,7 @@ class LicenseManagerAgentOps:
             "sacctmgr",
             "add",
             "account",
-            "license-manager",
+            _LICENSE_MANAGER_ACCOUNT,
             "Description=License Manager reservations account",
             "-i",
         ]
@@ -345,7 +345,7 @@ class LicenseManagerAgentOps:
         remove_user_cmd = [
             "sacctmgr",
             "remove",
-            "user"
+            "user",
             _LICENSE_MANAGER_USER,
             "-i",
         ]

--- a/src/license_manager_agent_ops.py
+++ b/src/license_manager_agent_ops.py
@@ -57,7 +57,7 @@ class LicenseManagerAgentOps:
         """Set up log dir."""
         # Delete log dir if it already exists
         if self._LOG_DIR.exists():
-            logger.debug(f"Clearing log dir {self._LOG_DIR.as_posix()}")
+            logger.debug(f"The log directory already exists. Clearing it: {self._LOG_DIR.as_posix()}")
             rmtree(self._LOG_DIR, ignore_errors=True)
         else:
             logger.debug(

--- a/src/templates/license-manager-agent.service.template
+++ b/src/templates/license-manager-agent.service.template
@@ -4,8 +4,8 @@ After=network.target
 
 [Service]
 Type=oneshot
-User=root
-Group=root
+User=license-manager
+Group=slurm
 WorkingDirectory=/srv/license-manager-agent-venv
 EnvironmentFile=-/etc/default/license-manager-agent
 ExecStart=/srv/license-manager-agent-venv/bin/reconcile


### PR DESCRIPTION
#### What
Update user creation to include `license-manager` user in the `slurm` group.
Also improve log, cache and user set up.

#### Why
The agent runs as `license-manager`, but the prolog/epilog scripts runs as `slurm`.
This is causing access issues with the cached token file.
Adding `license-manager` user to `slurm` group and changing the token permission to 660 (https://github.com/omnivector-solutions/license-manager/pull/205) solves the issue.

`Task`: https://jira.scania.com/browse/ASP-2608

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
