### PR TITLE
[ASP-4603] Add stat interval to agent's configuration

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ This file keeps track of all notable changes to the License Manager Agent Charm.
 
 Unreleased
 ----------
+- Include stat interval env var in the agent's configuration
 
 1.1.3 - 2023-12-11
 ------------------

--- a/src/license_manager_agent_ops.py
+++ b/src/license_manager_agent_ops.py
@@ -276,6 +276,7 @@ class LicenseManagerAgentOps:
             "use-reconcile-in-prolog-epilog"
         )
         deploy_env = charm_config.get("deploy-env")
+        stat_interval = charm_config.get("stat-interval")
 
         log_base_dir = str(self._LOG_DIR)
 
@@ -295,6 +296,7 @@ class LicenseManagerAgentOps:
             "oidc_client_secret": oidc_client_secret,
             "use_reconcile_in_prolog_epilog": use_reconcile_in_prolog_epilog,
             "deploy_env": deploy_env,
+            "stat_interval": stat_interval,
         }
 
         template_dir = Path("./src/templates/")

--- a/src/templates/license-manager.defaults.template
+++ b/src/templates/license-manager.defaults.template
@@ -24,3 +24,4 @@ LM2_AGENT_OIDC_CLIENT_ID={{ oidc_client_id }}
 LM2_AGENT_OIDC_CLIENT_SECRET={{ oidc_client_secret }}
 LM2_AGENT_CACHE_DIR=/var/cache/license-manager
 LM2_AGENT_DEPLOY_ENV={{ deploy_env }}
+LM2_AGENT_STAT_INTERVAL={{ stat_interval }}


### PR DESCRIPTION
#### What
Set up the env var stat interval in the agent's configuration.

#### Why
To keep the stat interval from the reconciliation in sync with the cluster status report.

`Task`: https://jira.scania.com/browse/ASP-4603

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
