### PR TITLE
[ASP-5422] Add TOOL_TIMEOUT env var as config

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,9 +6,17 @@ This file keeps track of all notable changes to the License Manager Agent Charm.
 
 Unreleased
 ----------
-* Update the charm to support installing the new License Manager Agent process [ASP-5383]
-* Remove support for CentOS7
+* Include `TOOL_TIMEOUT` env var in the agent's configuration [ASP-5422]
+
+1.2.1 - 2024-09-02
+-------------------
 * Add support to DSLS license server [ASP-5000]
+* Fix bug on upgrade action [ASP-5000]
+
+1.2.0 - 2024-09-02
+-------------------
+* Remove support for CentOS7
+* Update the charm to support installing the new License Manager Agent process [ASP-5383]
 
 1.1.4 - 2023-16-24
 ------------------

--- a/config.yaml
+++ b/config.yaml
@@ -29,6 +29,11 @@ options:
     default: 300
     description: |
       Interval (in seconds) at which the reconciliation process should run
+  tool-timeout:
+    type: int
+    default: 6
+    description: |
+      Timeout (in seconds) for the binaries command to run without raising an error
   lmutil-path:
     type: string
     default:


### PR DESCRIPTION
#### What
Add the env var `TOOL_TIMEOUT` as a configuration to the charm.

#### Why
The default value (6 seconds) is not enough for the new DSLS license server, since it takes longer to run.
Having this value as a configuration enables quick editing this value.

`Task`: https://jira.scania.com/browse/ASP-5422

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
